### PR TITLE
ci: makes breaking releases bump a version

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,14 @@
           "preset": "angular",
           "releaseRules": [
             {
+              "breaking": true,
+              "release": "major"
+            },
+            {
+              "revert": true,
+              "release": "patch"
+            },
+            {
               "type": "feat",
               "release": "minor"
             },


### PR DESCRIPTION
I think this is a mistake from overwriting the default behavior. 

I took inspiration for this update from here:
https://github.com/semantic-release/commit-analyzer/blob/2b9c73e1b4d63221980da18fd3d1f2817aaee1b8/lib/default-release-rules.js#L7

fixes #24