### PR TITLE
docs: update reame and examples documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,25 @@ A joi-compatible tool for building Swagger (Open API 3) documents. It enables de
 - 🔎 **Intellisense:** Really nice intellisense suggestions, and TypeScript definitions.
 - 🔒 **Type safety:** Bagger always produces 100% valid Swagger documents. If you use TypeScript the compiler will enforce correctness in most cases, and otherwise Bagger will validate during compilation.
 
+## Usage
+
+```js
+// Use the default Bagger instance
+const bagger = require('@digitalroute/bagger').default;
+
+// OR
+
+// Create a new instance
+const { Bagger } = require('@digitalroute/bagger');
+const bagger = new Bagger();
+```
+
 ## Example
 
 ```js
-const bagger = require('@digitalroute/bagger');
+const { Bagger } = require('@digitalroute/bagger');
 const joi = require('@hapi/joi');
+const bagger = new Bagger();
 
 bagger.configure({
   title: 'Bagger API',

--- a/README.md
+++ b/README.md
@@ -41,12 +41,10 @@ bagger.configure({
 });
 
 bagger
-  .addRequest()
-  .method('get')
-  .path('/bags')
-  .tag('bags')
-  .tag('build')
-  .responses([
+  .addRequest('/bags', 'get')
+  .addTag('bags')
+  .addTag('build')
+  .addResponse(
     bagger
       .response(200)
       .description('Successfully fetched all bags')
@@ -55,9 +53,9 @@ bagger
         joi
           .array()
           .items(joi.string())
-          .example(['handbag', 'backpack'])
+          .example([['handbag', 'backpack', 'purse']])
       )
-  ]);
+  );
 
 const swaggerDefinition = bagger.compile();
 ```

--- a/docs/01-introduction.md
+++ b/docs/01-introduction.md
@@ -36,7 +36,7 @@ Create a file called `server.js` in the project root directory:
 
 ```js
 const express = require('express');
-const bagger = require('@digitalroute/bagger');
+const bagger = require('@digitalroute/bagger').default;
 const swaggerUi = require('swagger-ui-express');
 const joi = require('@hapi/joi');
 
@@ -98,7 +98,7 @@ It is possible to configuer bagger in multiple files. The only important thing i
 Create a file called `accounts.js` in the project root directory:
 
 ```js
-const bagger = require('@digitalroute/bagger');
+const bagger = require('@digitalroute/bagger').default;
 
 bagger
   .addRequest('/accounts', 'get')
@@ -113,7 +113,7 @@ Update the beginning of `server.js` so that it includes `account.js`
 
 ```js
 const express = require('express');
-const bagger = require('@digitalroute/bagger');
+const bagger = require('@digitalroute/bagger').default;
 const swaggerUi = require('swagger-ui-express');
 const joi = require('@hapi/joi');
 require('./accounts'); // <-- new line

--- a/docs/02-api_reference.md
+++ b/docs/02-api_reference.md
@@ -48,7 +48,7 @@ To use bagger `bagger.configure().info(info)` has to be called before `bagger.co
 Get the configuration object for bagger. This defines the configuration for all endpoints.
 
 ```js
-const bagger = require('bagger');
+const bagger = require('bagger').default;
 bagger
   .configure()
   .info({
@@ -129,7 +129,7 @@ This method will compile all configuration done before the method call, and retu
 ```js
 const router = require('express').Router();
 const swaggerUi = require('swagger-ui-express');
-const bagger = require('@digitalroute/bagger');
+const bagger = require('@digitalroute/bagger').default;
 
 bagger.configure();
 // ...
@@ -150,7 +150,7 @@ Defining requests is the core of Swagger and OpenAPI 3. This method call will ad
 > **Important:** Every request has to have at least one defined response. Otherwise bagger will throw during compile.
 
 ```js
-const bagger = require('@digitalroute/bagger');
+const bagger = require('@digitalroute/bagger').default;
 const joi = require('@hapi/joi');
 
 bagger
@@ -240,7 +240,7 @@ All requests have to have at least one defined response. This returns a response
 Read [Describing Responses](https://swagger.io/docs/specification/describing-responses/) for more information.
 
 ```js
-const bagger = require('@digitalroute/bagger');
+const bagger = require('@digitalroute/bagger').default;
 const joi = require('@hapi/joi');
 
 const successfulResponse = bagger
@@ -355,7 +355,7 @@ WIP
 Create a parameter used for defining query, path, cookie or header parameter in bagger requests.
 
 ```js
-const bagger = require('bagger');
+const bagger = require('bagger').default;
 
 const parameter = bagger
   .parameter()


### PR DESCRIPTION
The latest version of bagger has changed its exports. This update to the documentation matches this change.