### PR TITLE
feat: Expose Joi along with Bagger instance. Fixes #60

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,29 +10,26 @@ A joi-compatible tool for building Swagger (Open API 3) documents. It enables de
 ## Features
 
 - 🔨 **Builder pattern:** Dead simple api to create complex Swagger documents.
-- ✨ **joi compatibility:** Enables developers to use the same schemas for validation and documentation.
+- ✨ **joi compatibility:** Enables developers to use the same schemas for validation and documentation. Embeded Joi is now exposed by default.
 - 🔎 **Intellisense:** Really nice intellisense suggestions, and TypeScript definitions.
 - 🔒 **Type safety:** Bagger always produces 100% valid Swagger documents. If you use TypeScript the compiler will enforce correctness in most cases, and otherwise Bagger will validate during compilation.
 
 ## Usage
 
 ```js
-// Use the default Bagger instance
-const bagger = require('@digitalroute/bagger').default;
+// Import as a classic javascript
+const bagger = require('@digitalroute/bagger').bagger;
 
 // OR
 
-// Create a new instance
-const { Bagger } = require('@digitalroute/bagger');
-const bagger = new Bagger();
+// Import the default instances ESModule / Typescript
+import { bagger } from '@digitalroute/bagger';
 ```
 
 ## Example
 
 ```js
-const { Bagger } = require('@digitalroute/bagger');
-const joi = require('@hapi/joi');
-const bagger = new Bagger();
+import { bagger, joi } from '@digitalroute/bagger';
 
 bagger.configure({
   title: 'Bagger API',

--- a/lib/bagger.ts
+++ b/lib/bagger.ts
@@ -192,5 +192,4 @@ export class Bagger {
   }
 }
 
-const defaultInstance = new Bagger();
-export default defaultInstance;
+export const defaultInstance = new Bagger();

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,0 +1,4 @@
+import { defaultInstance as bagger } from './bagger';
+import joi from 'joi';
+
+export { bagger, joi };

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "@digitalroute/bagger",
   "version": "0.0.0-semantically-released",
   "description": "🎒 A joi-compatible tool for building swagger definitions",
-  "main": "dist/bagger.umd.js",
-  "module": "dist/bagger.es5.js",
-  "typings": "dist/types/bagger.d.ts",
+  "main": "dist/index.umd.js",
+  "module": "dist/index.es5.js",
+  "typings": "dist/types/index.d.ts",
   "files": [
     "dist"
   ],

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -7,7 +7,7 @@ import json from 'rollup-plugin-json';
 
 const pkg = require('./package.json');
 
-const libraryName = 'bagger';
+const libraryName = 'index';
 
 export default {
   input: `lib/${libraryName}.ts`,


### PR DESCRIPTION
Breaking change: 

- exporting bagger & joi instances.
- switching export pattern to index instead of bagger class as we could in future expose other libraries if needed


Fixes #60 