### PR TITLE
feat: Export the full Bagger class

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,4 @@
-import { bagger } from './bagger';
+import { bagger, Bagger } from './bagger';
 import joi from 'joi';
 
-export { bagger, joi };
+export { bagger, joi, Bagger };


### PR DESCRIPTION
Export the full Bagger class so we can have multiple instances (one for each version of the API), instead of just the singleton.